### PR TITLE
Sprint#1 issue#100

### DIFF
--- a/amplify/backend/function/yAppLambda/src/Controllers/PostController.cs
+++ b/amplify/backend/function/yAppLambda/src/Controllers/PostController.cs
@@ -109,18 +109,19 @@ public class PostController : ControllerBase
     /// Retrieves all public posts from a user
     /// </summary>
     /// <param name="userName">The username used to find all posts created by a user.</param>
-    /// <returns>A list of public posts created by a user.</returns>
+    /// <param name="diaryEntry">If the query is for public posts or diary entries.</param>
+    /// <returns>A list of posts created by a user, either public posts or diary entries.</returns>
     [HttpGet("getPostsByUser")]
     [ProducesResponseType(typeof(List<Post>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<List<Post>>> GetPostsByUser(string userName)
+    public async Task<ActionResult<List<Post>>> GetPostsByUser(string userName, bool diaryEntry)
     {
         if(string.IsNullOrEmpty(userName))
         {
             return BadRequest("username is required");
         }
 
-        var posts = await _postActions.GetPostsByUser(userName);
+        var posts = await _postActions.GetPostsByUser(userName, diaryEntry);
 
         return posts;
     }

--- a/amplify/backend/function/yAppLambda/src/DynamoDB/IPostActions.cs
+++ b/amplify/backend/function/yAppLambda/src/DynamoDB/IPostActions.cs
@@ -23,6 +23,7 @@ public interface IPostActions
     /// Gets all public posts from a user
     /// </summary>
     /// <param name="userName">The username used to find all posts created by a user.</param>
-    /// <returns>A list of public posts created by a user.</returns>
-    Task<List<Post>> GetPostsByUser(string userName);
+    /// <param name="diaryEntry">If the query is for public posts or diary entries.</param>
+    /// <returns>A list of posts created by a user, either public posts or diary entries.</returns>
+    Task<List<Post>> GetPostsByUser(string userName, bool diaryEntry);
 }

--- a/amplify/backend/function/yAppLambda/src/DynamoDB/PostActions.cs
+++ b/amplify/backend/function/yAppLambda/src/DynamoDB/PostActions.cs
@@ -78,18 +78,19 @@ public class PostActions : IPostActions
     /// Gets all public posts from a user
     /// </summary>
     /// <param name="userName">The username used to find all posts created by a user.</param>
-    /// <returns>A list of public posts created by a user.</returns>
-    public async Task<List<Post>> GetPostsByUser(string userName)
+    /// <param name="diaryEntry">If the query is for public posts or diary entries.</param>
+    /// <returns>A list of posts created by a user, either public posts or diary entries.</returns>
+    public async Task<List<Post>> GetPostsByUser(string userName, bool diaryEntry)
     {
         try
         {
             List<ScanCondition> scanConditions = new List<ScanCondition>
             {
                 new ScanCondition("UserName", ScanOperator.Equal, userName),
-                new ScanCondition("DiaryEntry", ScanOperator.Equal, false)
+                new ScanCondition("DiaryEntry", ScanOperator.Equal, diaryEntry)
             };
 
-            // query posts where the poster's username is 'userName' and 'diaryEntry' is false
+            // query posts where the poster's username is 'userName' and 'diaryEntry' is equal to the input
             var posts = await _dynamoDbContext.ScanAsync<Post>(scanConditions, _config).GetRemainingAsync();
 
             return posts;

--- a/amplify/backend/function/yAppLambda/src/Postman/Posts.postman_collection.json
+++ b/amplify/backend/function/yAppLambda/src/Postman/Posts.postman_collection.json
@@ -96,12 +96,16 @@
           "method": "GET",
           "header": [],
           "url": {
-            "raw": "{{base_url}}/api/posts/getPostsByUser?userName=${userName}",
+            "raw": "{{base_url}}/api/posts/getPostsByUser?userName=${userName}&diaryEntry=${diaryEntry}",
             "host": ["{{base_url}}"],
             "path": ["api", "posts", "getPostsByUser"],
             "query": [
               {
                 "key": "userName",
+                "value": ""
+              },
+              {
+                "key": "diaryEntry",
                 "value": ""
               }
             ]


### PR DESCRIPTION
Quick bug fix to add functionality to getPostsByUser API endpoint to also be able to retrieve diary entries by a user based on a boolean parameter to indicate whether to query public posts or diary entries.

demo:
![getPostsByUser2](https://github.com/user-attachments/assets/0e161735-ca5a-4b3d-bbbb-e356d5aa46c9)
![getPostsByUser3](https://github.com/user-attachments/assets/0d2e8bd3-a41f-45b4-a121-dea35bda147f)
![getPostsByUser4](https://github.com/user-attachments/assets/696ad56f-0ced-4ede-b715-0d0f0042a7b5)
