### PR TITLE
Sprint#2 Issue#275

### DIFF
--- a/yAppMobile/app/src/main/java/com/example/yappmobile/NaviBarDestinations/PublicPostsActivity.java
+++ b/yAppMobile/app/src/main/java/com/example/yappmobile/NaviBarDestinations/PublicPostsActivity.java
@@ -119,7 +119,6 @@ public class PublicPostsActivity extends AppCompatActivity implements IListCardI
             loadMore.setVisibility(View.VISIBLE);
             currentDatePosition--;
             String since = dates.get(currentDatePosition);
-            dates.remove(currentDatePosition);
             refreshPosts(since);
         }
         else


### PR DESCRIPTION
This is a one-line PR to stop the go backwards button from being broken on mobile. To test this fix, page to the very last page and click the load more button until it goes away, then use the go back button and make sure the posts reflect what they should be from paging forwards.

Closes #275 